### PR TITLE
Uso kong 0.13 (alpine) en docker

### DIFF
--- a/kong.dockerfile
+++ b/kong.dockerfile
@@ -1,13 +1,13 @@
-FROM kong:0.12
+FROM kong:0.13
 
-ENV API_GATEWAY_PLUING_DIR=/api-gateway-httplog
+ENV API_GATEWAY_PLUING_DIR=/api-gateway-httplog \
+    API_GATEWAY_PLUING_BRANCH=master \
+    KONG_CUSTOM_PLUGINS=api-gateway-httplog
 
-RUN yum install git -y
+RUN apk add --no-cache git && \
+    git clone https://github.com/datosgobar/api-gateway-httplog.git $API_GATEWAY_PLUING_DIR && \
+    luarocks install json-lua && \
+    cd $API_GATEWAY_PLUING_DIR && luarocks make && \
+    apk del --no-cache git
 
-RUN git clone https://github.com/datosgobar/api-gateway-httplog.git $API_GATEWAY_PLUING_DIR
-
-ENV KONG_CUSTOM_PLUGINS=api-gateway-httplog
-
-RUN luarocks install json-lua && \
-    cd $API_GATEWAY_PLUING_DIR && luarocks make
 


### PR DESCRIPTION
Uso kong 0.13 en desarrollo.

Para probarlo:

```
# Volvemos a generar la imagen
docker-compose build kong
docker-compose up -d kong
# Corremos migraciones
 docker-compose run --rm kong kong migrations up
# Reiniciamos kong
 docker-compose restart kong
```
Despues de esos comandos, la aplicacion deberia seguir funcionando correctamente
