### PR TITLE
91 documentar endpoint queries 2

### DIFF
--- a/api_management/apps/analytics/swaggers.py
+++ b/api_management/apps/analytics/swaggers.py
@@ -1,0 +1,132 @@
+QUERIES = {
+    "swagger": "2.0",
+    "info": {
+        "description": "Endpoint analytics",
+        "version": "1.0",
+        "title": "Query Analytics",
+    },
+    "schemes": {
+        0: "http"
+    },
+    "paths": {
+        "/management/api/analytics/queries": {
+            "get": {
+                "summary": "Retorna las queries registradas",
+                "description": "Retorna paginadamente todas "
+                               "las queries registradas de todas las apis",
+                "consumes": {
+                    0: "application/json",
+                    1: "application/x-www-form-urlencoded",
+                    2: "multipart/form-data",
+                },
+                "produces": {
+                    0: "application/json",
+                    1: "text/html",
+                },
+                "parameters": {
+                    0: {
+                        "name": "kong_api_id",
+                        "in": "query",
+                        "description": "filtra por id de api",
+                        "required": False,
+                        "type": "string",
+                    },
+                    1: {
+                        "name": "from_date",
+                        "in": "query",
+                        "description": "filtra por fecha de query. "
+                                       "Se obtienen todas las queries "
+                                       "con fecha posterior a la indicada. YYYY-MM-DD",
+                        "required": False,
+                        "type": "string",
+                    },
+                    2: {
+                        "name": "to_date",
+                        "in": "query",
+                        "description": "filtra por fecha de query. "
+                                       "Se obtienen todas las queries "
+                                       "con fecha anterior a la indicada. YYYY-MM-DD",
+                        "required": False,
+                        "type": "string",
+                    },
+                    3: {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "indica tamaño de pagina",
+                        "required": False,
+                        "type": "integer",
+                    },
+                    4: {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "indica desplazamiento de pagina",
+                        "required": False,
+                        "type": "integer",
+                    },
+                },
+                "responses": {
+                    200: {
+                        "description": "operacion exitosa",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "count": {
+                                    "type": "integer",
+                                },
+                                "next": {
+                                    "type": "url",
+                                },
+                                "previous": {
+                                    "type": "url",
+                                },
+                                "results": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/Query",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+    "definitions": {
+        "Query": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                },
+                "ip_address": {
+                    "type": "string",
+                },
+                "host": {
+                    "type": "string",
+                },
+                "uri": {
+                    "type": "string",
+                },
+                "api_data": {
+                    "type": "integer",
+                },
+                "querystring": {
+                    "type": "string",
+                },
+                "start_time": {
+                    "type": "datetime",
+                },
+                "request_time": {
+                    "type": "decimal",
+                },
+                "status_code": {
+                    "type": "integer",
+                },
+                "user_agent": {
+                    "type": "string",
+                }
+            },
+        },
+    },
+}

--- a/api_management/apps/analytics/urls.py
+++ b/api_management/apps/analytics/urls.py
@@ -1,8 +1,13 @@
+from django.conf.urls import url
 from rest_framework import routers
 
-from .views import QueryViewSet
+from .views import QueryViewSet, query_swagger_view
 
 router = routers.SimpleRouter()  # pylint: disable=invalid-name
 router.register(r'queries', QueryViewSet)
 
 urlpatterns = router.urls  # pylint: disable=invalid-name
+
+urlpatterns += [
+    url(r'^queries/swagger/$', query_swagger_view, name='query-swagger'),
+]

--- a/api_management/apps/analytics/views.py
+++ b/api_management/apps/analytics/views.py
@@ -1,11 +1,13 @@
 
 from rest_framework import viewsets, mixins, status
 from rest_framework.authentication import TokenAuthentication
+from rest_framework.decorators import api_view
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
 from rest_framework.pagination import LimitOffsetPagination as DRFLimitOffsetPagination
 from django_filters import rest_framework as filters
 
+from api_management.apps.analytics import swaggers
 from .models import Query
 from .serializers import QuerySerializer
 from .tasks import make_model_object
@@ -35,3 +37,8 @@ class QueryViewSet(mixins.ListModelMixin, mixins.CreateModelMixin, viewsets.Gene
 
     def perform_create(self, serializer):
         make_model_object.delay(serializer.data, type(serializer))
+
+
+@api_view(['GET'])
+def query_swagger_view(*_, **__):
+    return Response(swaggers.QUERIES)

--- a/docs/django.md
+++ b/docs/django.md
@@ -93,3 +93,42 @@ curl localhost:8001/apis/$API_ID/plugins/ -d name=httplog2 -d config.endpoint=ht
 * [Pylint](https://pylint.readthedocs.io/en/latest/): `scripts/pylint.sh`
 * [Jscpd](https://github.com/kucherenko/jscpd): `scripts/jscpd.sh`
 * [Eslint](https://eslint.org/): `scripts/eslint.sh`
+
+## Analytics
+
+Los analytics de las apis con logs activados se obtienen haciendo GET `/management/api/analytics/queries/`
+
+
+| Parametro   | Descripcion                                                     |
+| -----------:|:--------------------------------------------------------------- |
+| limit       | Indica tamaño de pagina. Por defecto es `10`. Maximo es `1000`. |
+| offset      | Indica desplazamiento de pagina.                                |
+| kong_api_id | Id de api que se quiere filtrar.                                |
+| from_date   | Filtra queries posteriores a la fecha dada. Formato `YYYY-MM-DD`|
+| to_date     | Filtra queries anteriores a la fecha dada. Formato `YYYY-MM-DD` |
+
+#### Respuesta:
+```
+HTTP 200 OK
+```
+```
+{
+    "count": 2,
+    "next": "http://<kong>/management/api/analytics/queries/?limit=1&offset=1",
+    "previous": null,
+    "results": [
+        {
+            "id": 1,
+            "ip_address": "123.123.123.123",
+            "host": "datos.gob.ar",
+            "uri": "/series/v1/series/",
+            "api_data": null,
+            "querystring": "",
+            "start_time": "2018-01-05T13:30:00-03:00",
+            "request_time": "0.0001220000000000000000000",
+            "status_code": 200,
+            "user_agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:59.0) Gecko/20100101 Firefox/59.0"
+        }
+    ]
+}
+```

--- a/docs/django.md
+++ b/docs/django.md
@@ -96,7 +96,17 @@ curl localhost:8001/apis/$API_ID/plugins/ -d name=httplog2 -d config.endpoint=ht
 
 ## Analytics
 
-Los analytics de las apis con logs activados se obtienen haciendo GET `/management/api/analytics/queries/`
+Los analytics de las apis con logs activados se obtienen haciendo GET `/management/api/analytics/queries/`.
+
+Este endpoint requiere autenticacion por token.
+
+Se puede obtener un token con `curl -X POST <kong>/management/api/token/ -d username=<username> -d password=<password>`
+
+Para autenticarse enviar el token en el header `Authorization: Token <token>`.
+
+Se pueden obtener queries con `curl -X GET <kong>/management/api/analytics/queries/ -H 'Authorization: Token <token>'
+`
+
 
 
 | Parametro   | Descripcion                                                     |

--- a/docs/django.md
+++ b/docs/django.md
@@ -122,7 +122,7 @@ HTTP 200 OK
             "ip_address": "123.123.123.123",
             "host": "datos.gob.ar",
             "uri": "/series/v1/series/",
-            "api_data": null,
+            "api_data": 1,
             "querystring": "",
             "start_time": "2018-01-05T13:30:00-03:00",
             "request_time": "0.0001220000000000000000000",


### PR DESCRIPTION
- Agrego endpoint  `management/api/analytics/queries/swagger/` que retorna la especificación de endpoint de queries en formato swagger.

- Agrego a `docs/django.md` especificación de endpoint de queries.