### PR TITLE
Querystring to json

### DIFF
--- a/api_management/apps/analytics/models.py
+++ b/api_management/apps/analytics/models.py
@@ -1,14 +1,15 @@
-import uuid
 import hashlib
-
 import re
-import requests
+import uuid
+from urllib.parse import parse_qsl, urlparse
 
+import requests
 from django.conf import settings
 from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils.translation import gettext_lazy as _
+
 from api_management.apps.api_registry.models import KongApi
 
 
@@ -28,6 +29,12 @@ class Query(models.Model):
     class Meta:  # pylint: disable=too-few-public-methods
         verbose_name = _("query")
         verbose_name_plural = _("queries")
+
+    def params(self):
+        return dict(parse_qsl(
+            urlparse("https://example.com/?%s" % self.querystring).query,
+            keep_blank_values=True
+        ))
 
     def __str__(self):
         return 'Query at %s: %s' % (self.start_time, self.uri)

--- a/api_management/apps/analytics/serializers.py
+++ b/api_management/apps/analytics/serializers.py
@@ -9,5 +9,5 @@ class QuerySerializer(serializers.ModelSerializer):
         fields = (
             'id', 'ip_address', 'host', 'uri', 'api_data',
             'querystring', 'start_time', 'request_time', 'status_code',
-            'user_agent',
+            'user_agent', 'params',
         )

--- a/api_management/apps/analytics/test/api_tests.py
+++ b/api_management/apps/analytics/test/api_tests.py
@@ -10,7 +10,8 @@ from api_management.apps.analytics.test.support import query_dict_response
 faker = Faker()  # pylint: disable=invalid-name
 
 
-def test_analytics_api_valid_query(staff_user, well_formed_query, httplogdata): # pylint: disable=unused-argument
+# pylint: disable=unused-argument
+def test_analytics_api_valid_query(staff_user, well_formed_query, httplogdata):
     """
     Test cuando un staff_user le pega al endpoint de queries
     con un json de query bien formado responde con estado 201

--- a/api_management/apps/analytics/test/api_tests.py
+++ b/api_management/apps/analytics/test/api_tests.py
@@ -203,6 +203,4 @@ def test_filter_queries(staff_user,
     assert response.status_code == 200
     response_json = response.json()
     assert response_json['count'] == len(expected_results)
-    print(response_json['results'])
-    print(expected_results)
     assert response_json['results'] == expected_results

--- a/api_management/apps/analytics/test/conftest.py
+++ b/api_management/apps/analytics/test/conftest.py
@@ -1,12 +1,11 @@
-import requests_mock
-
 import pytest
+import requests_mock
 from faker import Faker
 
-from api_management.apps.analytics.test.support import custom_faker
-from api_management.apps.api_registry.test.support import generate_api_data
 from api_management.apps.analytics.models import GoogleAnalyticsManager, Query
+from api_management.apps.analytics.test.support import custom_faker
 from api_management.apps.api_registry.models import KongPluginHttpLog
+from api_management.apps.api_registry.test.support import generate_api_data
 
 
 # pylint: disable=redefined-outer-name
@@ -36,21 +35,28 @@ def staff_user(user):  # pylint: disable=unused-argument, invalid-name
     return user
 
 
-@pytest.fixture
-def well_formed_query(api_data):
-    faker = Faker()
-    return {
+def query_dict(faker_instance, api_data_pk, query_pk=None, start_time=None):
+    query = {
+
         "ip_address": "192.168.254.254",
-        "host": faker.domain_name(),
-        "uri": faker.uri_path(),
-        "querystring": faker.text(),
-        "start_time": faker.iso8601() + '-0300',
-        "request_time": 0.5,
+        "host": faker_instance.domain_name(),
+        "uri": faker_instance.uri_path(),
+        "querystring": "%s=%s" % (faker_instance.word(), faker_instance.word()),
+        "start_time": start_time or (faker_instance.iso8601() + '-0300'),
+        "request_time": "12.0000000000000000000000000",
         "status_code": 200,
-        "api_data": api_data.pk,  # Is required!
+        "api_data": api_data_pk,  # Is required!
         "user_agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:59.0) "
                       "Gecko/20100101 Firefox/59.0",
     }
+    if query_pk is not None:
+        query['id'] = query_pk
+    return query
+
+
+@pytest.fixture
+def well_formed_query(api_data, cfaker):
+    return query_dict(cfaker, api_data_pk=api_data.pk)
 
 
 @pytest.fixture

--- a/api_management/apps/analytics/test/query_tests.py
+++ b/api_management/apps/analytics/test/query_tests.py
@@ -1,0 +1,10 @@
+def test_query_has_params(query, cfaker):
+    query_string = "empty=&value=1&many=2,3&multiple=1&multiple=2"
+    query.querystring = query_string
+    assert query.params() == {"empty": "", "value": "1", "many": "2,3", "multiple": "2"}
+
+
+def test_query_without_params(query):
+    query_string = ""
+    query.querystring = query_string
+    assert query.params() == {}

--- a/api_management/apps/analytics/test/query_tests.py
+++ b/api_management/apps/analytics/test/query_tests.py
@@ -1,4 +1,4 @@
-def test_query_has_params(query, cfaker):
+def test_query_has_params(query):
     query_string = "empty=&value=1&many=2,3&multiple=1&multiple=2"
     query.querystring = query_string
     assert query.params() == {"empty": "", "value": "1", "many": "2,3", "multiple": "2"}

--- a/api_management/apps/analytics/test/support.py
+++ b/api_management/apps/analytics/test/support.py
@@ -1,3 +1,5 @@
+from urllib.parse import parse_qsl, urlparse
+
 from faker import Faker
 
 from api_management.libs.providers.providers import CustomInfoProvider
@@ -8,3 +10,16 @@ def custom_faker():
     a_faker = Faker()
     a_faker.add_provider(CustomInfoProvider)
     return a_faker
+
+
+def dict_from_querystring(querystring):
+    return dict(parse_qsl(
+        urlparse("https://example.com/?%s" % querystring).query,
+        keep_blank_values=True
+    ))
+
+
+def query_dict_response(query_dict):
+    response = query_dict.copy()
+    response['params'] = dict_from_querystring(query_dict['querystring'])
+    return response


### PR DESCRIPTION
Para probarlo:
- Crear una `Query` con "query_string"
- Pegarle a la API rest
- Verificar que devuelve una key "params" con un json con el valor parseado del "query_string"