### PR TITLE
Inicializar consumer anonimo

### DIFF
--- a/api_management/apps/api_registry/migrations/0011_add_missing_jwt_anonymous_consumer.py
+++ b/api_management/apps/api_registry/migrations/0011_add_missing_jwt_anonymous_consumer.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+
+
+def add_missing_consumer(apps, _):
+    KongApiPluginJwt = apps.get_model('api_registry', 'KongApiPluginJwt')
+    KongConsumer = apps.get_model('api_registry', 'KongConsumer')
+
+    for kongapipluginjwt in KongApiPluginJwt.objects.filter(anonymous_consumer=None):
+        KongConsumer.objects.create_anonymous(kongapipluginjwt.parent).save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('api_registry', '0010_auto_20180615_1101'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_missing_consumer),
+    ]

--- a/api_management/apps/api_registry/models.py
+++ b/api_management/apps/api_registry/models.py
@@ -232,14 +232,14 @@ class KongPlugin(KongObject):
 # pylint: disable=too-few-public-methods
 class KongConsumerManager(models.Manager):
 
-    ANONYMOUS_CONSUMER_APPLICANT = "anonymous"
-    ANONYMOUS_CONSUMER_EMAIL = "anon@anon.com"
+    anonymous_consumer_applicant = "anonymous"
+    anonymous_consumer_email = "anon@anon.com"
 
     def create_anonymous(self, api):
         return self.create(enabled=True,
                            api=api,
-                           applicant=self.ANONYMOUS_CONSUMER_APPLICANT,
-                           contact_email=self.ANONYMOUS_CONSUMER_EMAIL)
+                           applicant=self.anonymous_consumer_applicant,
+                           contact_email=self.anonymous_consumer_email)
 
     def create_from_request(self, token_request):
         return self.create(enabled=True,
@@ -534,11 +534,8 @@ def init_acl_plugin(created, instance, *_, **__):
 @receiver(post_save, sender=KongApiPluginJwt)
 def init_anon_user(created, instance, *_, **__):
     if created:
-        consumer = KongConsumer.objects.create(
-            enabled=True,
+        consumer = KongConsumer.objects.create_anonymous(
             api=instance.parent,
-            applicant="anonymous",
-            contact_email="anon@anon.com"
         )
         consumer.save()
 

--- a/api_management/apps/api_registry/models.py
+++ b/api_management/apps/api_registry/models.py
@@ -232,6 +232,15 @@ class KongPlugin(KongObject):
 # pylint: disable=too-few-public-methods
 class KongConsumerManager(models.Manager):
 
+    ANONYMOUS_CONSUMER_APPLICANT = "anonymous"
+    ANONYMOUS_CONSUMER_EMAIL = "anon@anon.com"
+
+    def create_anonymous(self, api):
+        return self.create(enabled=True,
+                           api=api,
+                           applicant=self.ANONYMOUS_CONSUMER_APPLICANT,
+                           contact_email=self.ANONYMOUS_CONSUMER_EMAIL)
+
     def create_from_request(self, token_request):
         return self.create(enabled=True,
                            api=token_request.api,


### PR DESCRIPTION
- Agrego migración de datos de django para crear consumer anónimos en los plugin jwt que no lo tengan.
- Refactor: centralizo la creación de consumer anónimos en KongConsumer Manager.

##### Como Testear:
- Correr migraciones en api-mgmt

##### Verificar:
- Plugins jwt que no tenian consumer anonimo ahora lo tienen.
- Se siguen inicializando de manera correcta nuevos consumers anónimos al activar por primera vez jwt en una api.

closes #111 