### PR TITLE
Fix fecha al generar analytics

### DIFF
--- a/api_management/apps/analytics/management/commands/generate_analytics.py
+++ b/api_management/apps/analytics/management/commands/generate_analytics.py
@@ -4,10 +4,11 @@ from django.utils import timezone
 
 from api_management.apps.analytics.models import Query, CsvAnalyticsGeneratorTask
 from api_management.apps.analytics.tasks import generate_analytics_dump
+from api_management.apps.common.utils import date_at_midnight
 
 
 def yesterday():
-    return timezone.now() - relativedelta.relativedelta(days=1)
+    return date_at_midnight(timezone.now()) - relativedelta.relativedelta(days=1)
 
 
 class Command(BaseCommand):
@@ -19,7 +20,7 @@ class Command(BaseCommand):
                 self.stdout.write("No hay queries cargadas.")
                 return
 
-            self.generate_all_analytics(first_query.start_time, yesterday())
+            self.generate_all_analytics(date_at_midnight(first_query.start_time), yesterday())
         else:
             self.generate_analytics_once()
 

--- a/api_management/apps/analytics/tasks.py
+++ b/api_management/apps/analytics/tasks.py
@@ -7,7 +7,7 @@ from api_management.apps.analytics.metrics_calculator import IndicatorMetricsCal
 from api_management.apps.analytics.models import CsvAnalyticsGeneratorTask, \
     IndicatorCsvGeneratorTask
 from api_management.apps.api_registry.models import KongApi
-from api_management.apps.common.utils import as_locale_datetime
+from api_management.apps.common.utils import as_local_datetime
 
 
 @job('create_model')
@@ -28,8 +28,8 @@ def generate_csv(generator, task_logger, api_name, analytics_date=None):
 
 @job('generate_analytics', timeout=3600)
 def generate_analytics_dump(analytics_date, task_logger=None):
-    locale_time = as_locale_datetime(timezone.now())
-    task_logger = task_logger or CsvAnalyticsGeneratorTask(created_at=locale_time)
+    local_time = as_local_datetime(timezone.now())
+    task_logger = task_logger or CsvAnalyticsGeneratorTask(created_at=local_time)
 
     for api in KongApi.objects.all():
         csv_generator = AnalyticsCsvGenerator(api_name=api.name, analytics_date=analytics_date)
@@ -38,8 +38,8 @@ def generate_analytics_dump(analytics_date, task_logger=None):
 
 @job('generate_indicators_csv', timeout=-1)  # no timeout
 def generate_indicators_csv(force, task_logger=None):
-    locale_time = as_locale_datetime(timezone.now())
-    task_logger = task_logger or IndicatorCsvGeneratorTask(created_at=locale_time)
+    local_time = as_local_datetime(timezone.now())
+    task_logger = task_logger or IndicatorCsvGeneratorTask(created_at=local_time)
 
     for api in KongApi.objects.all():
         IndicatorMetricsCalculator(api.name).calculate(force)

--- a/api_management/apps/analytics/tasks.py
+++ b/api_management/apps/analytics/tasks.py
@@ -7,6 +7,7 @@ from api_management.apps.analytics.metrics_calculator import IndicatorMetricsCal
 from api_management.apps.analytics.models import CsvAnalyticsGeneratorTask, \
     IndicatorCsvGeneratorTask
 from api_management.apps.api_registry.models import KongApi
+from api_management.apps.common.utils import as_locale_datetime
 
 
 @job('create_model')
@@ -27,7 +28,8 @@ def generate_csv(generator, task_logger, api_name, analytics_date=None):
 
 @job('generate_analytics', timeout=3600)
 def generate_analytics_dump(analytics_date, task_logger=None):
-    task_logger = task_logger or CsvAnalyticsGeneratorTask(created_at=timezone.now())
+    locale_time = as_locale_datetime(timezone.now())
+    task_logger = task_logger or CsvAnalyticsGeneratorTask(created_at=locale_time)
 
     for api in KongApi.objects.all():
         csv_generator = AnalyticsCsvGenerator(api_name=api.name, analytics_date=analytics_date)
@@ -36,7 +38,8 @@ def generate_analytics_dump(analytics_date, task_logger=None):
 
 @job('generate_indicators_csv', timeout=-1)  # no timeout
 def generate_indicators_csv(force, task_logger=None):
-    task_logger = task_logger or IndicatorCsvGeneratorTask(created_at=timezone.now())
+    locale_time = as_locale_datetime(timezone.now())
+    task_logger = task_logger or IndicatorCsvGeneratorTask(created_at=locale_time)
 
     for api in KongApi.objects.all():
         IndicatorMetricsCalculator(api.name).calculate(force)

--- a/api_management/apps/common/utils.py
+++ b/api_management/apps/common/utils.py
@@ -1,2 +1,15 @@
+import datetime
+from django.utils import timezone
+
+
 def same(number):
     return number
+
+
+def as_locale_datetime(a_date):
+    return a_date.astimezone(timezone.get_current_timezone())
+
+
+def date_at_midnight(a_date):
+    locale_date = as_locale_datetime(a_date)
+    return datetime.datetime(locale_date.year, locale_date.month, locale_date.day)

--- a/api_management/apps/common/utils.py
+++ b/api_management/apps/common/utils.py
@@ -6,10 +6,10 @@ def same(number):
     return number
 
 
-def as_locale_datetime(a_date):
+def as_local_datetime(a_date):
     return a_date.astimezone(timezone.get_current_timezone())
 
 
 def date_at_midnight(a_date):
-    locale_date = as_locale_datetime(a_date)
-    return datetime.datetime(locale_date.year, locale_date.month, locale_date.day)
+    local_date = as_local_datetime(a_date)
+    return datetime.datetime(local_date.year, local_date.month, local_date.day)


### PR DESCRIPTION
Closes #175

Las fechas usadas para generar los CSV arrancan a las 00 horas. De esta forma, no tenemos un rango donde podrían pisarse con el día anterior.