### PR TITLE
Filtro las Queries por api name

### DIFF
--- a/api_management/apps/analytics/csv_analytics/csv_generator.py
+++ b/api_management/apps/analytics/csv_analytics/csv_generator.py
@@ -127,7 +127,8 @@ class IndicatorCsvGenerator(AbstractCsvGenerator):
         return model
 
     def total_queries_by_date(self, row_date):
-        return Query.objects.filter(start_time__lt=next_day_of(row_date)).count()
+        return Query.objects.filter(api_data__name=self.api_name,
+                                    start_time__lt=next_day_of(row_date)).count()
 
     def total_historic_hits(self, row_date):
         all_queries = self.total_queries_by_date(row_date)

--- a/api_management/apps/analytics/csv_analytics/metrics_calculator.py
+++ b/api_management/apps/analytics/csv_analytics/metrics_calculator.py
@@ -57,7 +57,7 @@ class IndicatorMetricsCalculator:
         indicator_row.save()
 
     def calculate(self, force):
-        if Query.objects.filter(api_data__name=self.api_name).count() == 0:
+        if not Query.objects.filter(api_data__name=self.api_name).exists():
             return
 
         self.drop_metric_rows(force)

--- a/api_management/apps/analytics/csv_analytics/metrics_calculator.py
+++ b/api_management/apps/analytics/csv_analytics/metrics_calculator.py
@@ -34,7 +34,7 @@ class IndicatorMetricsCalculator:
                 'total_unique_users': len(unique_session_ids)}
 
     def first_query_time(self):
-        query_time = Query.objects.first().start_time.date()
+        query_time = Query.objects.filter(api_data__name=self.api_name).first().start_time.date()
         last_row = IndicatorMetricsRow.objects.filter(api_name=self.api_name).last()
         if last_row is not None:
             query_time = next_day_of(last_row.date)
@@ -57,6 +57,9 @@ class IndicatorMetricsCalculator:
         indicator_row.save()
 
     def calculate(self, force):
+        if Query.objects.filter(api_data__name=self.api_name).count() == 0:
+            return
+
         self.drop_metric_rows(force)
         query_time = self.first_query_time()
 


### PR DESCRIPTION
Closes #164 

El CSV de indicadores de las distintas apis arranca curiosamente con la misma fecha para georef y series. Además, arranca con el mismo valor de consultas acumuladas.
Esto se debe a que no se filtraban las queries a analizar por _api name_.
Este PR agrega el filtro por _api name_, lo que soluciona estos problemas.