### PR TITLE
Borro función suelta y lo agrego como método de Query

### DIFF
--- a/api_management/apps/analytics/csv_analytics/metrics_calculator.py
+++ b/api_management/apps/analytics/csv_analytics/metrics_calculator.py
@@ -1,7 +1,6 @@
 from datetime import date
 
-from api_management.apps.analytics.models import generate_api_session_id, IndicatorMetricsRow, \
-    Query, next_day_of
+from api_management.apps.analytics.models import IndicatorMetricsRow, Query, next_day_of
 
 
 class IndicatorMetricsCalculator:
@@ -21,7 +20,7 @@ class IndicatorMetricsCalculator:
         total_not_mobile = 0
 
         for query in (queries or []):
-            unique_session_ids.add(generate_api_session_id(query))
+            unique_session_ids.add(query.api_session_id())
 
             if self.is_mobile(query.user_agent):
                 total_mobile = total_mobile + 1

--- a/api_management/apps/analytics/models.py
+++ b/api_management/apps/analytics/models.py
@@ -66,10 +66,6 @@ def is_options_request(query):
     return query.request_method == 'OPTIONS'
 
 
-def generate_api_session_id(query):
-    return query.ip_address + query.api_data.name + query.user_agent
-
-
 class GoogleAnalyticsManager:
 
     @classmethod
@@ -117,14 +113,12 @@ class GoogleAnalyticsManager:
                 'cm3': query.api_data.pk,
                 'ua': query.user_agent}
 
-        api_session_id = generate_api_session_id(query)
-
-        if not self.redis_client.exists(api_session_id):
+        if not self.redis_client.exists(query.api_session_id()):
             data['sc'] = 'start'  # this request starts a new session
 
         min_to_timeout = ApiSessionSettings.get_solo().max_timeout
-        self.redis_client.append(api_session_id, 'start')
-        self.redis_client.expire(api_session_id, min_to_timeout*60)
+        self.redis_client.append(query.api_session_id(), 'start')
+        self.redis_client.expire(query.api_session_id(), min_to_timeout*60)
 
         return data
 

--- a/api_management/apps/analytics/test/send_analytics_tests.py
+++ b/api_management/apps/analytics/test/send_analytics_tests.py
@@ -77,9 +77,8 @@ def test_exclude_analytics_for_options_request(ga_manager, query):
 def set_up_redis(query):
     redis_client = Redis(host=settings.RQ_QUEUES["default"]["HOST"],
                          port=settings.RQ_QUEUES["default"]["PORT"])
-    api_session_id = query.ip_address + query.api_data.name + query.user_agent
-    redis_client.append(api_session_id, 'start')
-    redis_client.expire(api_session_id, 10)
+    redis_client.append(query.api_session_id(), 'start')
+    redis_client.expire(query.api_session_id(), 10)
 
 
 def exercise_manage_query(ga_manager, query, regex, uri, httplogdata):


### PR DESCRIPTION
Antes había una función suelta `generate_api_session_id` que tomaba una query y le pedía datos para generar una _session_id_. Ahora lo agregué como método de la clase Query, ya que tiene más sentido.