### PR TITLE
Valido que no exista un consumer antes de aceptar un token request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
 - docker-compose pull
 - docker-compose build
 - docker-compose up -d db kong redis kong_db
-- docker-compose run --rm kong kong migrations up
+- docker-compose run --rm kong kong migrations up --vv
 - docker-compose restart kong
 - docker-compose ps
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install:
 - docker-compose pull
 - docker-compose build
 - docker-compose up -d db kong redis kong_db
+- sleep 5
 - docker-compose run --rm kong kong migrations up --vv
 - docker-compose restart kong
 - docker-compose ps

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ before_install:
 - docker-compose pull
 - docker-compose build
 - docker-compose up -d db kong redis kong_db
+- docker-compose run --rm kong kong migrations up
+- docker-compose restart kong
 - docker-compose ps
 
 install:

--- a/api_management/apps/api_registry/admin.py
+++ b/api_management/apps/api_registry/admin.py
@@ -98,10 +98,11 @@ class TokenRequestAdmin(admin.ModelAdmin):
         for token_request in queryset:
             try:
                 token_request.accept()
-            except ValidationError:
+            except ValidationError as exc:
                 self.message_user(request,
-                                  'solicitud de %s no puede ser aceptada'
-                                  % token_request.applicant,
+                                  'solicitud de %s no puede ser aceptada: %s'
+                                  % (token_request.applicant,
+                                     exc.message),
                                   messages.WARNING)
 
     def reject(self, request, queryset):

--- a/api_management/apps/api_registry/test/conftest.py
+++ b/api_management/apps/api_registry/test/conftest.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from kong.structures import ApiData, PluginData
 
 from api_management.apps.analytics.test.support import custom_faker
-from api_management.apps.api_registry.models import KongApiPluginCors
+from api_management.apps.api_registry.models import KongApiPluginCors, TokenRequest
 from api_management.apps.api_registry.test.support import generate_api_data
 
 
@@ -93,3 +93,12 @@ def cors_plugin(cfaker, api_data):
     cors_plugin.origins = cfaker.uri()
 
     return cors_plugin
+
+
+@pytest.fixture()
+def token_request(api_data):
+    api_data.save()
+    return TokenRequest(api=api_data, applicant="Test User",
+                        contact_email="test@user.com",
+                        consumer_application="My app",
+                        requests_per_day=100)

--- a/api_management/apps/api_registry/test/token_requests_tests.py
+++ b/api_management/apps/api_registry/test/token_requests_tests.py
@@ -1,0 +1,36 @@
+import pytest
+from django.core.exceptions import ValidationError
+
+from api_management.apps.api_registry.models import ACCEPTED, KongConsumer
+
+pytestmark = pytest.mark.django_db
+
+
+def test_request_accepted(token_request):
+    token_request.accept()
+    assert token_request.state == ACCEPTED
+
+
+def test_request_cant_accept_twice(token_request):
+    token_request.accept()
+    with pytest.raises(ValidationError):
+        token_request.accept()
+
+
+def test_request_cant_reject_if_accepted(token_request):
+    token_request.accept()
+    with pytest.raises(ValidationError):
+        token_request.reject()
+
+
+def test_request_cant_accept_if_rejected(token_request):
+    token_request.reject()
+    with pytest.raises(ValidationError):
+        token_request.accept()
+
+
+def test_request_cant_accept_if_consumer_already_exists(token_request):
+    consumer = KongConsumer.objects.create_from_request(token_request)
+    consumer.save()
+    with pytest.raises(ValidationError):
+        token_request.accept()


### PR DESCRIPTION
Closes #214 

Problema: si ya existía un `KongConsumer` con mismo nombre / api que el `TokenRequest`, al aceptar tiraba un 500

Solución: validar la (no) existencia en el método `accept()` de `TokenRequest`

También agrego mensajes de error más descriptivos, para usar en el admin de django.